### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/cli_config_file_source.go
+++ b/cli_config_file_source.go
@@ -16,7 +16,7 @@ func FromDefaultCLIConfigFileSource() *CLIConfigFileSource {
 	return FromCLIConfigFileSource("config")
 }
 
-// FromDefaultCLIConfigFileSource registers a command line flag with the given flagName for specifying
+// FromCLIConfigFileSource registers a command line flag with the given flagName for specifying
 // an alternate JSON config file.
 func FromCLIConfigFileSource(flagName string) *CLIConfigFileSource {
 	return &CLIConfigFileSource{

--- a/directory_source.go
+++ b/directory_source.go
@@ -13,7 +13,7 @@ type DirectorySource struct {
 	path      string
 }
 
-// Reads the directory path provided. If the path does not exist, a panic will result.
+// FromDirectory reads the directory path provided. If the path does not exist, a panic will result.
 func FromDirectory(path string) *DirectorySource {
 	return &DirectorySource{
 		mustExist: true,
@@ -29,7 +29,7 @@ func FromOptionalDirectories(paths ...string) MultiSource {
 	return sources
 }
 
-// Reads the directory path provided, if it exists.
+// FromOptionalDirectory reads the directory path provided, if it exists.
 func FromOptionalDirectory(path string) *DirectorySource {
 	return &DirectorySource{
 		mustExist: false,

--- a/environment_source.go
+++ b/environment_source.go
@@ -25,7 +25,7 @@ func FromEnvironmentWithPrefix(prefix string) *EnvironmentSource {
 	return FromEnvironmentCustomSeparator(prefix, "|")
 }
 
-// FromEnvironmentWithPrefix creates an envirnoment source capable of
+// FromEnvironmentCustomSeparator creates an envirnoment source capable of
 // parsing values separated by the specified character.
 func FromEnvironmentCustomSeparator(prefix, separator string) *EnvironmentSource {
 	return &EnvironmentSource{prefix: prefix, separator: separator}

--- a/template.go
+++ b/template.go
@@ -52,7 +52,7 @@ func FromTemplateJSON(item *Template) *JSONSource {
 	}
 }
 
-// Execute the template
+// Run executes the template
 func (this *Template) Run() (ret []byte, err error) {
 	buf := new(bytes.Buffer)
 	tpl := template.New("self").Funcs(this.funcs())
@@ -76,7 +76,7 @@ func (this *Template) Run() (ret []byte, err error) {
 	return
 }
 
-// Execute the template, return as string
+// String executes the template, return as string
 func (this *Template) String() (ret string, err error) {
 	data, err := this.Run()
 	ret = string(data)


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html). It’s admittedly a relatively minor fix up. Does this help you?